### PR TITLE
Set 'token.redirect_url' and 'token.bank' after getToken() function comp...

### DIFF
--- a/VTiOSAPI/VTDirect.m
+++ b/VTiOSAPI/VTDirect.m
@@ -42,6 +42,8 @@
                 token.token_id = [jsonParsed objectForKey:@"token_id"];
                 token.status_code = [jsonParsed objectForKey:@"status_code"];
                 token.status_message = [jsonParsed objectForKey:@"status_message"];
+                token.redirect_url = [jsonParsed objectForKey:@"redirect_url"];
+                token.bank = [jsonParsed objectForKey:@"bank"];
                 completionHandler(token,nil);
             }else{
                 NSException* exception = [[NSException alloc] initWithName:@"JsonParsedException" reason:error.localizedDescription userInfo:error.userInfo];


### PR DESCRIPTION
This pull request patch bug on **VTDirect.getToken** _completionHandler_. This bug cause the redirect URL can't be opened, since it's return nothing.
